### PR TITLE
TASK: add the posibility to have an absolute path in the dotenv-include.php

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -19,6 +19,7 @@ class Config
      */
     public static $defaultConfig = [
         'env-file' => '.env',
+        'use-absoulte-path' => false,
     ];
 
     /**

--- a/src/IncludeFile.php
+++ b/src/IncludeFile.php
@@ -67,10 +67,15 @@ class IncludeFile
     private function getIncludeFileContent()
     {
         $envFile = $this->config->get('env-file');
-        $pathToEnvFileCode = $this->filesystem->findShortestPathCode(
-            $this->includeFile,
-            $envFile
-        );
+        $useAbsolutePath = $this->config->get('use-absoulte-path');
+        if ($useAbsolutePath) {
+            $pathToEnvFileCode = '\'' . realpath($envFile) .'\'';
+        } else {
+            $pathToEnvFileCode = $this->filesystem->findShortestPathCode(
+                $this->includeFile,
+                $envFile
+            );
+        }
         $includeFileContent = file_get_contents($this->includeFileTemplate);
         $includeFileContent = $this->replaceToken('env-file', $pathToEnvFileCode, $includeFileContent);
 

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -6,6 +6,18 @@ use Helhum\DotEnvConnector\IncludeFile;
 
 class IncludeFileTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function includeFileDataProvider() {
+        return [
+            'useRelativePath' => [
+                'useAbsolutePath' => false
+            ],
+            'useAbsolutePath' => [
+                'useAbsolutePath' => true
+            ]
+        ];
+    }
+
     protected function tearDown()
     {
         @unlink(__DIR__ . '/Fixtures/vendor/helhum/include.php');
@@ -17,11 +29,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider includeFileDataProvider
      */
-    public function dumpDumpsFile()
+    public function dumpDumpsFile($useAbsoultePath)
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $configProphecy->get('use-absoulte-path')->willReturn($useAbsoultePath);
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
         $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
@@ -30,11 +44,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider includeFileDataProvider
      */
-    public function includingFileExposesEnvVars()
+    public function includingFileExposesEnvVars($useAbsoultePath)
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $configProphecy->get('use-absoulte-path')->willReturn($useAbsoultePath);
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
         $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
@@ -45,11 +61,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider includeFileDataProvider
      */
-    public function includingFileDoesNothingIfEnvVarSet()
+    public function includingFileDoesNothingIfEnvVarSet($useAbsoultePath)
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $configProphecy->get('use-absoulte-path')->willReturn($useAbsoultePath);
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
         $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
@@ -61,11 +79,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider includeFileDataProvider
      */
-    public function includingFileDoesNothingIfEnvFileDoesNotExist()
+    public function includingFileDoesNothingIfEnvFileDoesNotExist($useAbsoultePath)
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.no-env');
+        $configProphecy->get('use-absoulte-path')->willReturn($useAbsoultePath);
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
         $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
@@ -76,11 +96,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider includeFileDataProvider
      */
-    public function dumpReturnsFalseIfFileCannotBeWritten()
+    public function dumpReturnsFalseIfFileCannotBeWritten($useAbsoultePath)
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.no-env');
+        $configProphecy->get('use-absoulte-path')->willReturn($useAbsoultePath);
         mkdir(__DIR__ . '/Fixtures/foo', 000);
         $includeFilePath = __DIR__ . '/Fixtures/foo/include.php';
         $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);


### PR DESCRIPTION
this is useful if the .env is outside of the project, so the project path
can be changed but .env is still loaded