### PR TITLE
[BUGFIX] Register class loading bevore parsing dotenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+# Do not build feature branches or alpha/beta releases
+branches:
+  only:
+    - master
+    - develop
+    - /^([0-9]+\.){1,2}(x|[0-9]+)$/
+
 notifications:
   email:
     - typo3@helhum.io

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Helhum\DotEnvConnector\Tests\Unit;
 
+use Composer\Autoload\ClassLoader;
 use Helhum\DotEnvConnector\Config;
 use Helhum\DotEnvConnector\IncludeFile;
 
@@ -22,8 +23,12 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
         $this->assertTrue(file_exists($includeFilePath));
     }
@@ -35,8 +40,12 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
         $this->assertTrue(file_exists($includeFilePath));
 
@@ -51,8 +60,12 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
         putenv('APP_ENV=1');
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
         $this->assertTrue(file_exists($includeFilePath));
 
@@ -66,8 +79,12 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.no-env');
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
         $includeFile->dump();
         $this->assertTrue(file_exists($includeFilePath));
 
@@ -81,9 +98,13 @@ class IncludeFileTest extends \PHPUnit_Framework_TestCase
     {
         $configProphecy = $this->prophesize(Config::class);
         $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.no-env');
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldNotBeCalled();
+        $loaderProphecy->unregister()->shouldNotBeCalled();
+
         mkdir(__DIR__ . '/Fixtures/foo', 000);
         $includeFilePath = __DIR__ . '/Fixtures/foo/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
         $this->assertFalse($includeFile->dump());
     }
 }


### PR DESCRIPTION
When we include the written include file during a composer run,
we need to make sure that classes used in this file are actually
loadable by the class loader.

Therefore register the class loader beforehand and unregister
it after we included the file.

Fixes: #9