### PR TITLE
Fixed constructing JsonFile from local config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -177,7 +177,7 @@ class Config
         if ($config === null) {
             $baseDir = realpath(substr($composerConfig->get('vendor-dir'), 0, -strlen($composerConfig->get('vendor-dir', self::RELATIVE_PATHS))));
             $localConfig = \Composer\Factory::getComposerFile();
-            $file = new \Composer\Json\JsonFile($localConfig, new \Composer\Util\RemoteFilesystem($io));
+            $file = new \Composer\Json\JsonFile($localConfig, null, $io);
 
             $config = new static($baseDir);
             $config->merge($file->read());


### PR DESCRIPTION
No need to pass a RemoteFilesystem object!?
This could lead to problems deep down in Composer\Util\StreamContextFactory when the local "url" is tested against NO_PROXY-patterns.