### PR TITLE
[BUGFIX] Fix exception occurring during upgrade

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -72,6 +72,7 @@ class Config
         }
         switch ($key) {
             case 'env-file':
+            case 'include-template-file':
                 $val = rtrim($this->process($this->config[$key], $flags), '/\\');
                 return ($flags & self::RELATIVE_PATHS === 1) ? $val : $this->realpath($val);
             default:

--- a/src/IncludeFile.php
+++ b/src/IncludeFile.php
@@ -52,7 +52,7 @@ class IncludeFile
         $this->filesystem = $filesystem ?: new Filesystem();
     }
 
-    public function dump()
+    public function dump(): bool
     {
         $this->filesystem->ensureDirectoryExists(dirname($this->includeFile));
         $successfullyWritten = false !== @file_put_contents($this->includeFile, $this->getIncludeFileContent());
@@ -73,10 +73,15 @@ class IncludeFile
      * @throws \InvalidArgumentException
      * @return string
      */
-    private function getIncludeFileContent()
+    private function getIncludeFileContent(): string
     {
         if (!file_exists($this->includeFileTemplate)) {
-            throw new \RuntimeException('Include file template defined for helhum/dotenv-connector does not exist!', 1581515568);
+            if (!empty($this->includeFileTemplate)) {
+                throw new \RuntimeException('Include file template defined for helhum/dotenv-connector does not exist!', 1581515568);
+            }
+            // We get here when include file template is empty, which could be a misconfiguration, but more likely happens
+            // during plugin package upgrades. In this case we provide the default value for smoother upgrades.
+            $this->includeFileTemplate = __DIR__ . '/../res/PHP/dotenv-include.php.tmpl';
         }
         $envFile = $this->config->get('env-file');
         $pathToEnvFileCode = $this->filesystem->findShortestPathCode(


### PR DESCRIPTION
Mitigate upgrade by providing the default template
in case none has been set, which happens when the old
config object is used during updating the plugin package.

Also allow to specify the template path relative to
Composer root directory.

Fixes: #22