### PR TITLE
Fix PHP 8.4 deprecation notice for implicitly marking parameter as nu…

### DIFF
--- a/src/IncludeFile.php
+++ b/src/IncludeFile.php
@@ -46,7 +46,7 @@ class IncludeFile
      */
     private $filesystem;
 
-    public function __construct(Config $config, ClassLoader $loader, string $includeFile = '', string $includeFileTemplate = null, Filesystem $filesystem = null)
+    public function __construct(Config $config, ClassLoader $loader, string $includeFile = '', ?string $includeFileTemplate = null, ?Filesystem $filesystem = null)
     {
         $this->config = $config;
         $this->loader = $loader;


### PR DESCRIPTION
…llable

Deprecation Notice: Helhum\DotEnvConnector\IncludeFile::__construct(): Implicitly marking parameter $includeFileTemplate as nullable is deprecated, the explicit nullable type must be used instead in vendor/helhum/dotenv-connector/src/IncludeFile.php:49

Deprecation Notice: Helhum\DotEnvConnector\IncludeFile::__construct(): Implicitly marking parameter $filesystem as nullable is deprecated, the explicit nullable type must be used instead in vendor/helhum/dotenv-connector/src/IncludeFile.php:49

Closes #47 https://github.com/helhum/dotenv-connector/issues/47