### PR TITLE
[FEATURE] Add SymfonyOverload adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,20 @@ need to be enclosed in single quotes.
 This may be the case if you use hashed values of credentials you pass via `.env`, for example.
 
 #### `adapter`
-You can specify a class that implements `\Helhum\DotEnvConnector\DotEnvVars` interface,
-if you need a different way to expose env vars.
+You can specify a class that implements the `\Helhum\DotEnvConnector\DotEnvVars` interface if you need a different way
+to expose environment variables. This package ships with three adapters for the `symfony/dotenv` component.
 
-*The default value* is "Helhum\DotEnvConnector\Adapter\SymfonyDotEnv",
-which uses symfony/dotenv default parsing of the one .env file.
+* `Helhum\DotEnvConnector\Adapter\SymfonyDotEnv` (Default): Uses `$dotenv->load()`.
+  * This loads variables from your `.env` file but will not overwrite any existing environment variables.
+  * The loading is skipped if an `APP_ENV` environment variable is already set.
+* `Helhum\DotEnvConnector\Adapter\SymfonyOverload`: Uses `$dotenv->overload()`.
+  * This is similar to the default adapter, but it will overwrite any existing environment variables with the values from your `.env` file.
+  * The loading is also skipped if an [APP_ENV]() environment variable is already set.
+* `Helhum\DotEnvConnector\Adapter\SymfonyLoadEnv`: Uses `$dotenv->loadEnv()`.
+  * This adapter uses Symfony's more powerful loading mechanism, which can load multiple files (`.env`, `.env.local`, `.env.$APP_ENV.local`, etc.).
+  * It does not check for the existence of `APP_ENV` before running.
 
-This could be useful though e.g. if you prefer to use another dotenv parsing library to expose the variables defined in .env
-or you want to switch to another parsing strategy of the Symfony dotenv parsing. In the latter case use
-"Helhum\DotEnvConnector\Adapter\SymfonyLoadEnv" as value for this option.
+You can also provide your own implementation if you want to use a different dotenv library.
 Have a look at the existing implementations for examples.
 
 ## Feedback

--- a/src/Adapter/SymfonyOverload.php
+++ b/src/Adapter/SymfonyOverload.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Helhum\DotEnvConnector\Adapter;
+
+use Helhum\DotEnvConnector\DotEnvVars;
+use Symfony\Component\Dotenv\Dotenv;
+
+class SymfonyOverload implements DotEnvVars
+{
+    public function exposeToEnvironment(string $dotEnvFile): void
+    {
+        if (!getenv('APP_ENV') && file_exists($dotEnvFile)) {
+            $dotEnv = new Dotenv();
+            $dotEnv->usePutenv();
+            $dotEnv->overload($dotEnvFile);
+        }
+    }
+}


### PR DESCRIPTION

Introduce a new `SymfonyOverload` adapter that uses the `$dotenv->overload()`
method from the `symfony/dotenv` component.

Unlike the existing `SymfonyDotEnv` adapter, which uses `$dotenv->load()` and
preserves pre-existing environment variables, this adapter ensures that `.env`
variables take precedence by overwriting existing values.

Useful in development scenarios where system-level environment variables must
be overridden for specific projects.