### PR TITLE
[FEATURE] Add option to override existing env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 /.php-cs-fixer.cache
+/.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,7 +5,9 @@ if (PHP_SAPI !== 'cli') {
 // Define in which folders to search and which folders to exclude
 // Exclude some directories that are excluded by Git anyways to speed up the sniffing
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__ . '/src/');
+    ->in(__DIR__ . '/src/')
+    ->in(__DIR__ . '/tests/')
+;
 
 $configFinder = PhpCsFixer\Finder::create()
     ->in(__DIR__)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ to do so and also set `APP_ENV` and use the variables that are directly exposed 
 However for smaller scale projects it is still a valid and easy solution to use a `.env` file
 also for production environments.
 
+You can set the environment variable `DOTENV_CONNECTOR_OVERRIDE` to enable overriding of existing environment variables with the values of the `.env` file.
+
 ## configuration options
 
 Usually you don't need any configuration options. However if you need to, you can

--- a/src/Adapter/SymfonyDotEnv.php
+++ b/src/Adapter/SymfonyDotEnv.php
@@ -13,7 +13,11 @@ class SymfonyDotEnv implements DotEnvVars
         if (!getenv('APP_ENV') && file_exists($dotEnvFile)) {
             $dotEnv = new Dotenv();
             $dotEnv->usePutenv();
-            $dotEnv->load($dotEnvFile);
+            if (getenv('DOTENV_CONNECTOR_OVERRIDE')) {
+                $dotEnv->overload($dotEnvFile);
+            } else {
+                $dotEnv->load($dotEnvFile);
+            }
         }
     }
 }

--- a/src/Adapter/SymfonyLoadEnv.php
+++ b/src/Adapter/SymfonyLoadEnv.php
@@ -13,7 +13,7 @@ class SymfonyLoadEnv implements DotEnvVars
         if (is_file($dotEnvFile) || is_file("$dotEnvFile.dist")) {
             $dotEnv = new Dotenv();
             $dotEnv->usePutenv();
-            $dotEnv->loadEnv($dotEnvFile);
+            $dotEnv->loadEnv($dotEnvFile, null, 'dev', ['test'], (bool)getenv('DOTENV_CONNECTOR_OVERRIDE'));
         }
     }
 }

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -6,7 +6,6 @@ use Helhum\DotEnvConnector\Adapter\SymfonyDotEnv;
 use Helhum\DotEnvConnector\Config;
 use Helhum\DotEnvConnector\IncludeFile;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophet;
 
 class IncludeFileTest extends TestCase
 {
@@ -19,6 +18,9 @@ class IncludeFileTest extends TestCase
         }
         putenv('FOO');
         putenv('APP_ENV');
+        putenv('DOTENV_CONNECTOR_OVERRIDE');
+        unset($_ENV['FOO'], $_ENV['APP_ENV'], $_ENV['DOTENV_CONNECTOR_OVERRIDE'], $_ENV['SYMFONY_DOTENV_VARS']);
+        unset($_SERVER['FOO'], $_SERVER['APP_ENV'], $_SERVER['DOTENV_CONNECTOR_OVERRIDE'], $_SERVER['SYMFONY_DOTENV_VARS']);
         if (file_exists(__DIR__ . '/Fixtures/foo')) {
             chmod(__DIR__ . '/Fixtures/foo', 777);
             rmdir(__DIR__ . '/Fixtures/foo');
@@ -28,14 +30,13 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function dumpDumpsFile()
+    public function dumpDumpsFile(): void
     {
         $config = new Config();
         $config->merge(['extra' => ['helhum/dotenv-connector' => [
             'env-file' => __DIR__ . '/Fixtures/env/.env',
             'adapter' => SymfonyDotEnv::class
         ]]]);
-        /** @var ClassLoader|\PHPUnit\Framework\MockObject\MockObject $loaderMock */
         $loaderMock = $this->createMock(ClassLoader::class);
         $loaderMock->expects($this->once())->method('register');
         $loaderMock->expects($this->once())->method('unregister');
@@ -49,14 +50,13 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function includingFileExposesEnvVars()
+    public function includingFileExposesEnvVars(): void
     {
         $config = new Config();
         $config->merge(['extra' => ['helhum/dotenv-connector' => [
             'env-file' => __DIR__ . '/Fixtures/env/.env',
             'adapter' => SymfonyDotEnv::class
         ]]]);
-        /** @var ClassLoader|\PHPUnit\Framework\MockObject\MockObject $loaderMock */
         $loaderMock = $this->createMock(ClassLoader::class);
         $loaderMock->expects($this->once())->method('register');
         $loaderMock->expects($this->once())->method('unregister');
@@ -72,7 +72,7 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function includingFileDoesNothingIfEnvVarSet()
+    public function includingFileDoesNothingIfEnvVarSet(): void
     {
         putenv('APP_ENV=1');
         $config = new Config();
@@ -80,7 +80,6 @@ class IncludeFileTest extends TestCase
             'env-file' => __DIR__ . '/Fixtures/env/.env',
             'adapter' => SymfonyDotEnv::class
         ]]]);
-        /** @var ClassLoader|\PHPUnit\Framework\MockObject\MockObject $loaderMock */
         $loaderMock = $this->createMock(ClassLoader::class);
         $loaderMock->expects($this->once())->method('register');
         $loaderMock->expects($this->once())->method('unregister');
@@ -96,14 +95,13 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function includingFileDoesNothingIfEnvFileDoesNotExist()
+    public function includingFileDoesNothingIfEnvFileDoesNotExist(): void
     {
         $config = new Config();
         $config->merge(['extra' => ['helhum/dotenv-connector' => [
             'env-file' => __DIR__ . '/Fixtures/env/.no-env',
             'adapter' => SymfonyDotEnv::class
         ]]]);
-        /** @var ClassLoader|\PHPUnit\Framework\MockObject\MockObject $loaderMock */
         $loaderMock = $this->createMock(ClassLoader::class);
         $loaderMock->expects($this->once())->method('register');
         $loaderMock->expects($this->once())->method('unregister');
@@ -119,14 +117,13 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function dumpReturnsFalseIfFileCannotBeWritten()
+    public function dumpReturnsFalseIfFileCannotBeWritten(): void
     {
         $config = new Config();
         $config->merge(['extra' => ['helhum/dotenv-connector' => [
             'env-file' => __DIR__ . '/Fixtures/env/.no-env',
             'adapter' => SymfonyDotEnv::class
         ]]]);
-        /** @var ClassLoader|\PHPUnit\Framework\MockObject\MockObject $loaderMock */
         $loaderMock = $this->createMock(ClassLoader::class);
         $loaderMock->expects($this->once())->method('register');
         $loaderMock->expects($this->once())->method('unregister');
@@ -140,20 +137,23 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function includingFileDoesNotOverrideExistingEnvVars()
+    public function includingFileDoesNotOverrideExistingEnvVars(): void
     {
         putenv('FOO=baz');
-        $configProphecy = $this->prophesize(Config::class);
-        $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
-        $configProphecy->get('adapter')->willReturn(SymfonyDotEnv::class);
-        $loaderProphecy = $this->prophesize(ClassLoader::class);
-        $loaderProphecy->register()->shouldBeCalled();
-        $loaderProphecy->unregister()->shouldBeCalled();
+        $_ENV['FOO'] = 'baz';
+        $config = new Config();
+        $config->merge(['extra' => ['helhum/dotenv-connector' => [
+            'env-file' => __DIR__ . '/Fixtures/env/.env',
+            'adapter' => SymfonyDotEnv::class
+        ]]]);
+        $loaderMock = $this->createMock(ClassLoader::class);
+        $loaderMock->expects($this->once())->method('register');
+        $loaderMock->expects($this->once())->method('unregister');
 
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
         $includeFile->dump();
-        $this->assertTrue(file_exists($includeFilePath));
+        $this->assertFileExists($includeFilePath);
 
         $this->assertSame('baz', getenv('FOO'));
     }
@@ -161,21 +161,24 @@ class IncludeFileTest extends TestCase
     /**
      * @test
      */
-    public function includingFileDoesOverrideExistingEnvVars()
+    public function includingFileDoesOverrideExistingEnvVars(): void
     {
         putenv('FOO=baz');
+        $_ENV['FOO'] = 'baz';
         putenv('DOTENV_CONNECTOR_OVERRIDE=1');
-        $configProphecy = $this->prophesize(Config::class);
-        $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
-        $configProphecy->get('adapter')->willReturn(SymfonyDotEnv::class);
-        $loaderProphecy = $this->prophesize(ClassLoader::class);
-        $loaderProphecy->register()->shouldBeCalled();
-        $loaderProphecy->unregister()->shouldBeCalled();
+        $config = new Config();
+        $config->merge(['extra' => ['helhum/dotenv-connector' => [
+            'env-file' => __DIR__ . '/Fixtures/env/.env',
+            'adapter' => SymfonyDotEnv::class
+        ]]]);
+        $loaderMock = $this->createMock(ClassLoader::class);
+        $loaderMock->expects($this->once())->method('register');
+        $loaderMock->expects($this->once())->method('unregister');
 
         $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
-        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
+        $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
         $includeFile->dump();
-        $this->assertTrue(file_exists($includeFilePath));
+        $this->assertFileExists($includeFilePath);
 
         $this->assertSame('bar', getenv('FOO'));
     }

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -136,4 +136,47 @@ class IncludeFileTest extends TestCase
         $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
         $this->assertFalse($includeFile->dump());
     }
+
+    /**
+     * @test
+     */
+    public function includingFileDoesNotOverrideExistingEnvVars()
+    {
+        putenv('FOO=baz');
+        $configProphecy = $this->prophesize(Config::class);
+        $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $configProphecy->get('adapter')->willReturn(SymfonyDotEnv::class);
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
+        $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
+        $includeFile->dump();
+        $this->assertTrue(file_exists($includeFilePath));
+
+        $this->assertSame('baz', getenv('FOO'));
+    }
+
+    /**
+     * @test
+     */
+    public function includingFileDoesOverrideExistingEnvVars()
+    {
+        putenv('FOO=baz');
+        putenv('DOTENV_CONNECTOR_OVERRIDE=1');
+        $configProphecy = $this->prophesize(Config::class);
+        $configProphecy->get('env-file')->willReturn(__DIR__ . '/Fixtures/env/.env');
+        $configProphecy->get('adapter')->willReturn(SymfonyDotEnv::class);
+        $loaderProphecy = $this->prophesize(ClassLoader::class);
+        $loaderProphecy->register()->shouldBeCalled();
+        $loaderProphecy->unregister()->shouldBeCalled();
+
+        $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
+        $includeFile = new IncludeFile($configProphecy->reveal(), $loaderProphecy->reveal(), $includeFilePath);
+        $includeFile->dump();
+        $this->assertTrue(file_exists($includeFilePath));
+
+        $this->assertSame('bar', getenv('FOO'));
+    }
 }


### PR DESCRIPTION
This adds an option to override existing environment variables with values from the `.env` file by setting the `DOTENV_CONNECTOR_OVERRIDE` environment variable.

The implementation uses the `overload()` method in the `SymfonyDotEnv` adapter and the corresponding parameter in the `SymfonyLoadEnv` adapter.