### PR TITLE
Add SymfonyDotEnvLocal adapter and make it the default (load .env.local out of the box)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You configure dotenv connector in the extra section of the root `composer.json` 
   "extra": {
       "helhum/dotenv-connector": {
           "env-file": ".env",
-          "adapter": "Helhum\\DotEnvConnector\\Adapter\\SymfonyDotEnv"
+          "adapter": "Helhum\\DotEnvConnector\\Adapter\\SymfonyDotEnvLocal"
       }
     }
 ```
@@ -58,24 +58,51 @@ This may be the case if you use hashed values of credentials you pass via `.env`
 You can specify a class that implements `\Helhum\DotEnvConnector\DotEnvVars` interface,
 if you need a different way to expose env vars.
 
-*The default value* is "Helhum\DotEnvConnector\Adapter\SymfonyDotEnv",
-which uses symfony/dotenv default parsing of the one .env file.
+*The default value* is "Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal",
+which loads `.env` and then `.env.local` on top of it (see below).
 
-This could be useful though e.g. if you prefer to use another dotenv parsing library to expose the variables defined in .env
-or you want to switch to another parsing strategy of the Symfony dotenv parsing.
+> **Upgrading from 3.x:** the default adapter changed from `SymfonyDotEnv` (which loads a single
+> `.env` file) to `SymfonyDotEnvLocal` (which also loads `.env.local`). If a project has a
+> `.env.local` file, it is now loaded automatically. To keep the previous behaviour, explicitly set
+> the adapter to `Helhum\DotEnvConnector\Adapter\SymfonyDotEnv`.
 
-Bundled alternatives:
+You may set this to any class implementing the `DotEnvVars` interface if you prefer another parsing
+strategy or another dotenv parsing library.
 
-* `Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal` — loads `.env` and then `.env.local`
-  on top of it, so shared defaults can live in `.env` (committed) and per-instance overrides in
-  `.env.local` (git-ignored). Values in `.env.local` override those from `.env`; neither overrides
-  variables already present in the real environment unless `DOTENV_CONNECTOR_OVERRIDE` is set. Like
-  the default, it does nothing when `APP_ENV` is set, and — unlike `SymfonyLoadEnv` — it does not load
-  per-environment files (`.env.$APP_ENV` etc.) and never writes `APP_ENV`. Use this when you want a
-  local override file but have no notion of an `APP_ENV` cascade (e.g. TYPO3 projects).
+Bundled adapters:
+
+* `Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal` *(default)* — loads `.env` and then
+  `.env.local` on top of it, so shared defaults can live in `.env` (committed) and per-instance
+  overrides in `.env.local` (git-ignored). Values in `.env.local` override those from `.env`; neither
+  overrides variables already present in the real environment unless `DOTENV_CONNECTOR_OVERRIDE` is
+  set. It does nothing when `APP_ENV` is set, and — unlike `SymfonyLoadEnv` — it does not load
+  per-environment files (`.env.$APP_ENV` etc.) and never writes `APP_ENV`. This keeps the model to
+  exactly two files for projects (e.g. TYPO3) that have no notion of an `APP_ENV` cascade.
+* `Helhum\DotEnvConnector\Adapter\SymfonyDotEnv` — the previous default; loads a single `.env` file
+  only, using symfony/dotenv's default parsing. Set the adapter to this to restore 3.x behaviour.
 * `Helhum\DotEnvConnector\Adapter\SymfonyLoadEnv` — uses Symfony's `loadEnv()`, loading the full
   Symfony cascade: `.env`, `.env.local`, `.env.$APP_ENV` and `.env.$APP_ENV.local` (and a `.env.dist`
   fallback). `APP_ENV` selects which environment files are layered on and defaults to `dev`.
+
+##### Why `SymfonyDotEnvLocal` and not just `SymfonyLoadEnv`?
+
+`SymfonyLoadEnv` already loads `.env.local` — but only as one step of Symfony's full environment
+cascade, which is keyed on `APP_ENV`: it also pulls in `.env.$APP_ENV` / `.env.$APP_ENV.local`,
+defaults `APP_ENV` to `dev`, and writes that value back into the environment. That is the right
+behaviour inside a Symfony application, where `APP_ENV` is the central environment switch.
+
+Most consumers of this package, however, only want the simple "shared `.env`, overridden per
+instance by `.env.local`" pattern and have no `APP_ENV` notion at all — TYPO3, for instance, keys
+its environment off `TYPO3_CONTEXT` and never reads `APP_ENV`. For them the cascade is conceptual
+overhead with surprising side effects (a stray `.env.dev` suddenly contributing values, an
+unexpected `APP_ENV` appearing in the environment).
+
+`SymfonyDotEnvLocal` exists to cover exactly that two-file case and nothing more. Crucially it also
+preserves `APP_ENV`'s meaning *as it already works in this package* — a kill switch that skips
+dotenv parsing entirely (e.g. in production, where real environment variables are provided) — rather
+than repurposing `APP_ENV` as a file selector the way `loadEnv()` does. That made it a safe choice
+for the default: the common case works out of the box, while the only behavioural change from the
+previous default is that an existing `.env.local` is now loaded.
 
 Have a look at the existing implementations for examples.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,21 @@ if you need a different way to expose env vars.
 which uses symfony/dotenv default parsing of the one .env file.
 
 This could be useful though e.g. if you prefer to use another dotenv parsing library to expose the variables defined in .env
-or you want to switch to another parsing strategy of the Symfony dotenv parsing. In the latter case use
-"Helhum\DotEnvConnector\Adapter\SymfonyLoadEnv" as value for this option.
+or you want to switch to another parsing strategy of the Symfony dotenv parsing.
+
+Bundled alternatives:
+
+* `Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal` — loads `.env` and then `.env.local`
+  on top of it, so shared defaults can live in `.env` (committed) and per-instance overrides in
+  `.env.local` (git-ignored). Values in `.env.local` override those from `.env`; neither overrides
+  variables already present in the real environment unless `DOTENV_CONNECTOR_OVERRIDE` is set. Like
+  the default, it does nothing when `APP_ENV` is set, and — unlike `SymfonyLoadEnv` — it does not load
+  per-environment files (`.env.$APP_ENV` etc.) and never writes `APP_ENV`. Use this when you want a
+  local override file but have no notion of an `APP_ENV` cascade (e.g. TYPO3 projects).
+* `Helhum\DotEnvConnector\Adapter\SymfonyLoadEnv` — uses Symfony's `loadEnv()`, loading the full
+  Symfony cascade: `.env`, `.env.local`, `.env.$APP_ENV` and `.env.$APP_ENV.local` (and a `.env.dist`
+  fallback). `APP_ENV` selects which environment files are layered on and defaults to `dev`.
+
 Have a look at the existing implementations for examples.
 
 ## Feedback

--- a/src/Adapter/SymfonyDotEnvLocal.php
+++ b/src/Adapter/SymfonyDotEnvLocal.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Helhum\DotEnvConnector\Adapter;
+
+use Helhum\DotEnvConnector\DotEnvVars;
+use Symfony\Component\Dotenv\Dotenv;
+
+/**
+ * Loads ".env" and then ".env.local" on top of it, so shared defaults can live in
+ * ".env" (committed) while per-instance overrides live in ".env.local" (git-ignored).
+ *
+ * Values from ".env.local" override those from ".env". Neither overrides variables
+ * already present in the real environment, unless DOTENV_CONNECTOR_OVERRIDE is set.
+ *
+ * Like {@see SymfonyDotEnv} this does nothing when APP_ENV is set, so the
+ * "real environment variables are already provided" production workflow is preserved.
+ * Unlike {@see SymfonyLoadEnv} it does NOT load per-environment files
+ * (".env.$APP_ENV", ".env.$APP_ENV.local", ".env.dist") and never writes APP_ENV —
+ * keeping the model to exactly two files for projects (e.g. TYPO3) that have no
+ * notion of an APP_ENV cascade.
+ */
+class SymfonyDotEnvLocal implements DotEnvVars
+{
+    public function exposeToEnvironment(string $dotEnvFile): void
+    {
+        if (getenv('APP_ENV')) {
+            return;
+        }
+
+        $dotEnv = new Dotenv();
+        $dotEnv->usePutenv();
+        $override = (bool)getenv('DOTENV_CONNECTOR_OVERRIDE');
+
+        foreach ([$dotEnvFile, $dotEnvFile . '.local'] as $file) {
+            if (!file_exists($file)) {
+                continue;
+            }
+            if ($override) {
+                $dotEnv->overload($file);
+            } else {
+                $dotEnv->load($file);
+            }
+        }
+    }
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,7 +10,7 @@ namespace Helhum\DotEnvConnector;
  * file that was distributed with this source code.
  */
 
-use Helhum\DotEnvConnector\Adapter\SymfonyDotEnv;
+use Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal;
 
 class Config
 {
@@ -21,7 +21,7 @@ class Config
      */
     public static $defaultConfig = [
         'env-file' => '.env',
-        'adapter' => SymfonyDotEnv::class,
+        'adapter' => SymfonyDotEnvLocal::class,
     ];
 
     /**

--- a/src/IncludeFile.php
+++ b/src/IncludeFile.php
@@ -13,7 +13,7 @@ namespace Helhum\DotEnvConnector;
 use Composer\Autoload\ClassLoader;
 use Composer\Composer;
 use Composer\Util\Filesystem;
-use Helhum\DotEnvConnector\Adapter\SymfonyDotEnv;
+use Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal;
 
 class IncludeFile
 {
@@ -79,7 +79,7 @@ class IncludeFile
     private function getIncludeFileContent(): string
     {
         $envFile = $this->config->get('env-file');
-        $adapterClass = $this->config->get('adapter') ?: SymfonyDotEnv::class;
+        $adapterClass = $this->config->get('adapter') ?: SymfonyDotEnvLocal::class;
         if (!in_array(DotEnvVars::class, class_implements($adapterClass), true)) {
             throw new \RuntimeException(sprintf('Adapter "%s" does not implement DotEnvVars interface', $adapterClass), 1598957197);
         }

--- a/tests/Unit/Fixtures/env/.env.local
+++ b/tests/Unit/Fixtures/env/.env.local
@@ -1,0 +1,2 @@
+FOO=local
+LOCAL_ONLY=yes

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -3,6 +3,7 @@ namespace Helhum\DotEnvConnector\Tests\Unit;
 
 use Composer\Autoload\ClassLoader;
 use Helhum\DotEnvConnector\Adapter\SymfonyDotEnv;
+use Helhum\DotEnvConnector\Adapter\SymfonyDotEnvLocal;
 use Helhum\DotEnvConnector\Config;
 use Helhum\DotEnvConnector\IncludeFile;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +18,11 @@ class IncludeFileTest extends TestCase
             rmdir(__DIR__ . '/Fixtures/vendor');
         }
         putenv('FOO');
+        putenv('LOCAL_ONLY');
         putenv('APP_ENV');
         putenv('DOTENV_CONNECTOR_OVERRIDE');
-        unset($_ENV['FOO'], $_ENV['APP_ENV'], $_ENV['DOTENV_CONNECTOR_OVERRIDE'], $_ENV['SYMFONY_DOTENV_VARS']);
-        unset($_SERVER['FOO'], $_SERVER['APP_ENV'], $_SERVER['DOTENV_CONNECTOR_OVERRIDE'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        unset($_ENV['FOO'], $_ENV['LOCAL_ONLY'], $_ENV['APP_ENV'], $_ENV['DOTENV_CONNECTOR_OVERRIDE'], $_ENV['SYMFONY_DOTENV_VARS']);
+        unset($_SERVER['FOO'], $_SERVER['LOCAL_ONLY'], $_SERVER['APP_ENV'], $_SERVER['DOTENV_CONNECTOR_OVERRIDE'], $_SERVER['SYMFONY_DOTENV_VARS']);
         if (file_exists(__DIR__ . '/Fixtures/foo')) {
             chmod(__DIR__ . '/Fixtures/foo', 777);
             rmdir(__DIR__ . '/Fixtures/foo');
@@ -181,5 +183,53 @@ class IncludeFileTest extends TestCase
         $this->assertFileExists($includeFilePath);
 
         $this->assertSame('bar', getenv('FOO'));
+    }
+
+    /**
+     * @test
+     */
+    public function localAdapterLoadsLocalEnvOnTopOfEnv(): void
+    {
+        $config = new Config();
+        $config->merge(['extra' => ['helhum/dotenv-connector' => [
+            'env-file' => __DIR__ . '/Fixtures/env/.env',
+            'adapter' => SymfonyDotEnvLocal::class
+        ]]]);
+        $loaderMock = $this->createMock(ClassLoader::class);
+        $loaderMock->expects($this->once())->method('register');
+        $loaderMock->expects($this->once())->method('unregister');
+
+        $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
+        $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
+        $includeFile->dump();
+        $this->assertFileExists($includeFilePath);
+
+        // .env defines FOO=bar; .env.local overrides it to "local" and adds LOCAL_ONLY
+        $this->assertSame('local', getenv('FOO'));
+        $this->assertSame('yes', getenv('LOCAL_ONLY'));
+    }
+
+    /**
+     * @test
+     */
+    public function localAdapterDoesNothingIfEnvVarSet(): void
+    {
+        putenv('APP_ENV=1');
+        $config = new Config();
+        $config->merge(['extra' => ['helhum/dotenv-connector' => [
+            'env-file' => __DIR__ . '/Fixtures/env/.env',
+            'adapter' => SymfonyDotEnvLocal::class
+        ]]]);
+        $loaderMock = $this->createMock(ClassLoader::class);
+        $loaderMock->expects($this->once())->method('register');
+        $loaderMock->expects($this->once())->method('unregister');
+
+        $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
+        $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
+        $includeFile->dump();
+        $this->assertFileExists($includeFilePath);
+
+        $this->assertFalse(getenv('FOO'));
+        $this->assertFalse(getenv('LOCAL_ONLY'));
     }
 }

--- a/tests/Unit/IncludeFileTest.php
+++ b/tests/Unit/IncludeFileTest.php
@@ -232,4 +232,28 @@ class IncludeFileTest extends TestCase
         $this->assertFalse(getenv('FOO'));
         $this->assertFalse(getenv('LOCAL_ONLY'));
     }
+
+    /**
+     * @test
+     */
+    public function defaultAdapterLoadsLocalEnvOnTopOfEnv(): void
+    {
+        $config = new Config();
+        // No 'adapter' configured -> the package default is used
+        $config->merge(['extra' => ['helhum/dotenv-connector' => [
+            'env-file' => __DIR__ . '/Fixtures/env/.env',
+        ]]]);
+        $loaderMock = $this->createMock(ClassLoader::class);
+        $loaderMock->expects($this->once())->method('register');
+        $loaderMock->expects($this->once())->method('unregister');
+
+        $includeFilePath = __DIR__ . '/Fixtures/vendor/helhum/include.php';
+        $includeFile = new IncludeFile($config, $loaderMock, $includeFilePath);
+        $includeFile->dump();
+        $this->assertFileExists($includeFilePath);
+
+        // The default adapter is now SymfonyDotEnvLocal, so .env.local is loaded on top of .env
+        $this->assertSame('local', getenv('FOO'));
+        $this->assertSame('yes', getenv('LOCAL_ONLY'));
+    }
 }


### PR DESCRIPTION
Fixes: #27 

## Summary

  Adds a new `DotEnvVars` adapter, `SymfonyDotEnvLocal`, that loads `.env` and then `.env.local`
  on top of it, and proposes it as the **default** adapter so the common "shared defaults +
  per-instance override" pattern works with no configuration.

  Two separate commits:
  
  1. `[FEATURE] Add adapter loading .env.local on top of .env` — the new adapter, fully
     backward-compatible (opt-in via the `adapter` option). Safe for a 3.x release on its own.
  2. `[!!!] Make SymfonyDotEnvLocal the default adapter` — flips the default. This is the only
     breaking change and is what makes the feature work out of the box; it's intended for a new
     major.

  They're kept apart on purpose: if you'd rather not change the default yet, commit 1 stands alone.

  ## Why not just use `SymfonyLoadEnv`?

  `SymfonyLoadEnv` already loads `.env.local` — but only as one step of Symfony's full,
  `APP_ENV`-keyed cascade: it also pulls in `.env.$APP_ENV` / `.env.$APP_ENV.local`, defaults
  `APP_ENV` to `dev`, and writes that value back into the environment. That's the right behaviour
  inside a Symfony application.

  But many consumers of this package have no `APP_ENV` notion at all — TYPO3, for example, keys its
  environment off `TYPO3_CONTEXT` and never reads `APP_ENV`. For them the cascade is conceptual
  overhead with surprising side effects (a stray `.env.dev` contributing values, an unexpected
  `APP_ENV` appearing). They just want `.env` + `.env.local`.

  Crucially, `SymfonyDotEnvLocal` **preserves `APP_ENV`'s existing meaning in this package** — a kill
  switch that skips dotenv parsing entirely (e.g. in production, where real env vars are provided) —
  instead of repurposing `APP_ENV` as a file selector the way `loadEnv()` does.

  ## Behaviour of `SymfonyDotEnvLocal`

  - Loads `.env`, then `.env.local` (derived as `"<env-file>.local"`).
  - `.env.local` overrides `.env`; neither overrides a variable already set in the real environment
    unless `DOTENV_CONNECTOR_OVERRIDE` is set (consistent with `SymfonyDotEnv`).
  - Does nothing when `APP_ENV` is set (unchanged kill-switch semantics).
  - Does **not** load per-environment files and never writes `APP_ENV`.

  ## Breaking change & migration
  
  The default adapter changes from `SymfonyDotEnv` (single `.env`) to `SymfonyDotEnvLocal`. The only
  observable difference is that a project containing a `.env.local` will now load it automatically.

  To keep the previous behaviour, set the adapter explicitly:

  ```json
  "extra": {
      "helhum/dotenv-connector": {
          "adapter": "Helhum\\DotEnvConnector\\Adapter\\SymfonyDotEnv"
      }
  }
  ```

  (Documented under "Upgrading from 3.x" in the README.) `branch-alias` is left untouched — happy to
  adjust for whichever version you target.

  ## Tests

  Extends `tests/Unit/IncludeFileTest.php`:

  - `localAdapterLoadsLocalEnvOnTopOfEnv` — `.env.local` overrides `.env` and adds new vars.
  - `localAdapterDoesNothingIfEnvVarSet` — `APP_ENV` kill-switch preserved.
  - `defaultAdapterLoadsLocalEnvOnTopOfEnv` — with no adapter configured, the new default loads
    `.env.local`.

  Full suite green: **10 tests, 31 assertions**.
